### PR TITLE
fix: Failure when copying repositories

### DIFF
--- a/git-manager/clone-repos.sh
+++ b/git-manager/clone-repos.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 file with repo URLs"
+    exit 1
+fi
+
+repo_file=$1
+target_directory=$2
+
+
+if [ ! -f "$repo_file" ]; then
+    echo "File does not exist: $repo_file"
+    exit 1
+fi
+
+if [ ! -d "$target_directory" ]; then
+    echo "Directory does not exist: $target_directory"
+    exit 1
+fi
+
+cd "$target_directory" || { echo "Failed to change directory to $target_directory"; exit 1; }
+
+while IFS= read -r repo_url; do
+    if [ -n "$repo_url" ]; then
+        git clone "$repo_url"
+    fi
+done < "$repo_file"
+
+echo "Cloning completed."

--- a/git-manager/repo-paths
+++ b/git-manager/repo-paths
@@ -1,7 +1,14 @@
+https://github.com/ecmsp-project/order-service.git
 https://github.com/ecmsp-project/product-service.git
 https://github.com/ecmsp-project/payment-service.git
-https://github.com/ecmsp-project/order-service.git
 https://github.com/ecmsp-project/user-service.git
 https://github.com/ecmsp-project/cart-service.git
-https://github.com/ecmsp-project/docs.git
+https://github.com/ecmsp-project/proto-stubs-view
 https://github.com/ecmsp-project/schema-definitions.git
+https://github.com/ecmsp-project/docs.git
+https://github.com/ecmsp-project/manifests-kubernetes
+https://github.com/ecmsp-project/message-broker-service
+https://github.com/ecmsp-project/temporary-files
+https://github.com/ecmsp-project/meta-manager
+https://github.com/ecmsp-project/elasticsearch-service
+https://github.com/ecmsp-project/gateway-service


### PR DESCRIPTION
## Why
The current solution had problems supporting Apple's M4 Pro processor architecture.
When attempting to run the `git-manager/manager-macos` script, an error occurred

```
❯ ./manager-macos
zsh: bad CPU type in executable: ./manager-macos
```
## How
Added the `clone-repos.sh` file, which appears to be a safer option than compiled files, and added new repositories to `repo-paths`